### PR TITLE
User Journey tests for Weather component & improvements to Weather component

### DIFF
--- a/cypress/e2e/weatherWidget.cy.js
+++ b/cypress/e2e/weatherWidget.cy.js
@@ -1,0 +1,37 @@
+import { MainPageObject } from "../pageObjects/pageObject";
+// const { cy } = require("date-fns/locale")
+const mainPageObject = new MainPageObject();
+
+describe("User Journey", () => {
+  beforeEach(() => {
+    mainPageObject.visit();
+  })
+
+  it("allows a user to enter a city and load the current weather, then change their city", () => {
+    cy.intercept({
+      url: 'http://localhost:3000/api/weather*',
+      query: { city: 'Toronto, Ontario, Canada' },
+    }).as('getWeather')
+
+    cy.get("[data-testid='weather-form']").type('Toronto')
+    cy.get("[data-testid='cityPicker-0']").click()
+    cy.wait('@getWeather')
+    cy.get("[data-testid='weather-info']").should("exist").contains('in Toronto')
+  })
+
+  it("allows a user to change their city", () => {
+    cy.intercept({
+      url: 'http://localhost:3000/api/weather*',
+      query: { city: 'Atlanta, Georgia, United States' },
+    }).as('getWeather')
+
+    cy.get("[data-testid='SettingsIcon']").eq(0).click()
+    cy.get("[data-testid='ChangeCity']").click()
+    cy.get("[data-testid='weather-form']").type('Atlanta')
+    cy.get("[data-testid='cityPicker-0']").click()
+    cy.get("[data-testid='CloseIcon']").eq(0).click()
+    cy.wait('@getWeather')
+    cy.get("[data-testid='weather-info']").should("exist").contains('in Atlanta')
+  })
+
+})

--- a/cypress/e2e/weatherWidget.cy.js
+++ b/cypress/e2e/weatherWidget.cy.js
@@ -24,29 +24,31 @@ describe("User Journey", () => {
     cy.get("[data-testid='cityPicker-0']").click()
     
     // cy.wait('@getWeather')
-    cy.get("[data-testid='weather-info']").should("exist").contains('in Toronto')
+    cy.get("[data-testid='weather-info']", { timeout: 15000 }).should("exist").contains('in Toronto')
   })
 
   it("allows a user to change their city", () => {
 
-    cy.intercept({
-      url: 'http://localhost:3000/api/city*',
-      query: { city: 'Atlanta' },
-    }).as('getCity')
+    // cy.intercept({
+    //   url: 'http://localhost:3000/api/city*',
+    //   query: { city: 'Atlanta' },
+    // }).as('getCity')
 
-    cy.intercept({
-      url: 'http://localhost:3000/api/weather*',
-      query: { city: 'Atlanta, Georgia, United States' },
-    }).as('getWeather')
+    // cy.intercept({
+    //   url: 'http://localhost:3000/api/weather*',
+    //   query: { city: 'Atlanta, Georgia, United States' },
+    // }).as('getWeather')
 
     cy.get("[data-testid='SettingsIcon']").eq(0).click()
     cy.get("[data-testid='ChangeCity']").click()
     cy.get("[data-testid='weather-form']").type('Atlanta')
-    cy.get("[data-testid='cityPicker-0']").click()
-    cy.wait('@getCity')
+    cy.get("[data-testid='cityPicker-0']", { timeout: 15000 }).click()
+
+    // cy.wait('@getCity')
     cy.get("[data-testid='CloseIcon']").eq(0).click()
-    cy.wait('@getWeather')
-    cy.get("[data-testid='weather-info']").should("exist").contains('in Atlanta')
+    
+    // cy.wait('@getWeather')
+    cy.get("[data-testid='weather-info']", { timeout: 15000 }).should("exist").contains('in Atlanta')
   })
 
 })

--- a/cypress/e2e/weatherWidget.cy.js
+++ b/cypress/e2e/weatherWidget.cy.js
@@ -8,18 +8,31 @@ describe("User Journey", () => {
   })
 
   it("allows a user to enter a city and load the current weather, then change their city", () => {
+    cy.get("[data-testid='weather-form']").type('Toronto')
+
+    cy.intercept({
+      url: 'http://localhost:3000/api/city*',
+      query: { city: 'Toronto' },
+    }).as('getCity')
+
     cy.intercept({
       url: 'http://localhost:3000/api/weather*',
       query: { city: 'Toronto, Ontario, Canada' },
     }).as('getWeather')
-
-    cy.get("[data-testid='weather-form']").type('Toronto')
+    
+    cy.wait('@getCity')
     cy.get("[data-testid='cityPicker-0']").click()
     cy.wait('@getWeather')
     cy.get("[data-testid='weather-info']").should("exist").contains('in Toronto')
   })
 
   it("allows a user to change their city", () => {
+
+    cy.intercept({
+      url: 'http://localhost:3000/api/city*',
+      query: { city: 'Atlanta' },
+    }).as('getCity')
+
     cy.intercept({
       url: 'http://localhost:3000/api/weather*',
       query: { city: 'Atlanta, Georgia, United States' },
@@ -28,6 +41,7 @@ describe("User Journey", () => {
     cy.get("[data-testid='SettingsIcon']").eq(0).click()
     cy.get("[data-testid='ChangeCity']").click()
     cy.get("[data-testid='weather-form']").type('Atlanta')
+    cy.wait('@getCity')
     cy.get("[data-testid='cityPicker-0']").click()
     cy.get("[data-testid='CloseIcon']").eq(0).click()
     cy.wait('@getWeather')

--- a/cypress/e2e/weatherWidget.cy.js
+++ b/cypress/e2e/weatherWidget.cy.js
@@ -7,22 +7,23 @@ describe("User Journey", () => {
     mainPageObject.visit();
   })
 
-  it("allows a user to enter a city and load the current weather, then change their city", () => {
+  it.only("allows a user to enter a city name, choose their city and load the current weather", () => {
     cy.get("[data-testid='weather-form']").type('Toronto')
 
-    cy.intercept({
-      url: 'http://localhost:3000/api/city*',
-      query: { city: 'Toronto' },
-    }).as('getCity')
+    // cy.intercept({
+    //   url: 'http://localhost:3000/api/city*',
+    //   query: { city: 'Toronto' },
+    // }).as('getCity')
 
-    cy.intercept({
-      url: 'http://localhost:3000/api/weather*',
-      query: { city: 'Toronto, Ontario, Canada' },
-    }).as('getWeather')
+    // cy.intercept({
+    //   url: 'http://localhost:3000/api/weather*',
+    //   query: { city: 'Toronto, Ontario, Canada' },
+    // }).as('getWeather')
     
-    cy.wait('@getCity')
+    // cy.wait('@getCity')
     cy.get("[data-testid='cityPicker-0']").click()
-    cy.wait('@getWeather')
+    
+    // cy.wait('@getWeather')
     cy.get("[data-testid='weather-info']").should("exist").contains('in Toronto')
   })
 
@@ -41,8 +42,8 @@ describe("User Journey", () => {
     cy.get("[data-testid='SettingsIcon']").eq(0).click()
     cy.get("[data-testid='ChangeCity']").click()
     cy.get("[data-testid='weather-form']").type('Atlanta')
-    cy.wait('@getCity')
     cy.get("[data-testid='cityPicker-0']").click()
+    cy.wait('@getCity')
     cy.get("[data-testid='CloseIcon']").eq(0).click()
     cy.wait('@getWeather')
     cy.get("[data-testid='weather-info']").should("exist").contains('in Atlanta')

--- a/cypress/e2e/weatherWidget.cy.js
+++ b/cypress/e2e/weatherWidget.cy.js
@@ -1,5 +1,5 @@
+/* global cy */
 import { MainPageObject } from "../pageObjects/pageObject";
-// const { cy } = require("date-fns/locale")
 const mainPageObject = new MainPageObject();
 
 describe("User Journey", () => {

--- a/cypress/e2e/weatherWidget.cy.js
+++ b/cypress/e2e/weatherWidget.cy.js
@@ -7,7 +7,7 @@ describe("User Journey", () => {
     mainPageObject.visit();
   })
 
-  it.only("allows a user to enter a city name, choose their city and load the current weather", () => {
+  it("allows a user to enter a city name, choose their city and load the current weather", () => {
     cy.get("[data-testid='weather-form']").type('Toronto')
 
     // cy.intercept({

--- a/cypress/pageObjects/pageObject.js
+++ b/cypress/pageObjects/pageObject.js
@@ -1,3 +1,5 @@
+/* global cy */
+
 export class MainPageObject {
   constructor() {
     this.settingsIcon = "[data-testid='SettingsIcon']";

--- a/src/components/WeatherForm/WeatherForm.jsx
+++ b/src/components/WeatherForm/WeatherForm.jsx
@@ -1,99 +1,139 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import {
-  citySelector,
   updateCity,
-  updateWeather,
 } from '../../features/weather/weatherSlice';
 import { changeCitySelector, changeCity } from '../../routes/settingsSlice';
 import TextField from '@mui/material/TextField';
-import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
+import styles from './WeatherForm.module.css';
 
 const WeatherForm = () => {
   const dispatch = useDispatch();
 
-  const city = useSelector(citySelector);
   const wantToChangeCity = useSelector(changeCitySelector);
 
   const [localCity, setLocalCity] = useState('');
   const [autocompleteCities, setAutocompleteCities] = useState([]);
   const [autocompleteErr, setAutocompleteErr] = useState('');
 
+  const debouncedCity = useDebounce(localCity, 500);
+
   // More on this city picker here: https://javascript.plainenglish.io/create-a-simple-city-autocomplete-field-in-react-f7675d249c74#5057
-  const handleCityChange = async (e) => {
+  const handleCityChange = (e) => {
     setLocalCity(e.target.value);
-
-    const response = await fetch(`/api/city?city=${localCity}`);
-    if (response.ok) {
-      const data = await response.json();
-      !autocompleteCities.includes(e.target.value) &&
-        data.features &&
-        setAutocompleteCities(data.features.map((place) => place.place_name));
-    }
-
-    response.error
-      ? setAutocompleteErr(response.error)
-      : setAutocompleteErr('');
   };
+
+  useEffect(() => {
+    const fetchCities = async () => {
+      if (!debouncedCity || autocompleteCities.includes(debouncedCity)) return;
+
+      try {
+        const response = await fetch(`/api/city?city=${debouncedCity}`);
+        if (response.ok) {
+          const data = await response.json();
+          setAutocompleteCities(data.features.map((place) => place.place_name));
+        } else {
+          setAutocompleteErr('Failed to fetch cities');
+        }
+      } catch (error) {
+        console.error('Error fetching cities:', error);
+        setAutocompleteErr('An error occurred');
+      }
+    };
+
+    fetchCities();
+  }, [debouncedCity]);
 
   const handleSubmit = (e) => {
     e.preventDefault();
     if (localCity) {
-      dispatch(updateCity(localCity));
-      fetchWeather();
+      dispatch(updateCity(e.target.textContent)); // this used to be e.target.value when it was taking the input
+      // fetchWeather(e.target.textContent);
       dispatch(changeCity(!wantToChangeCity));
+      setLocalCity(e.target.textContent);
     }
   };
 
-  const fetchWeather = async () => { //uncommented this function to clear eslint errors
-    try {
-      const response = await fetch(`/api/weather?city=${city}`);
-      if (response.ok) {
-        const data = await response.json();
-        dispatch(updateWeather(data));
-      } else {
-        console.log(`Error: ${response.statusText}`);
-        return <p>No weather data</p>;
-      }
-    } catch (error) {
-      console.log(error);
-    }
-  };
+  // const fetchWeather = async (newCity) => {
+  //   try {
+  //     const response = await fetch(`/api/weather?city=${newCity}`);
+  //     if (response.ok) {
+  //       const data = await response.json();
+  //       dispatch(updateWeather(data));
+  //     } else {
+  //       console.log(`Error: ${response.statusText}`);
+  //       return <p>No weather data</p>;
+  //     }
+  //   } catch (error) {
+  //     console.log(error);
+  //   }
+  // };
 
   return (
-      <form onSubmit={handleSubmit}>
-        <label htmlFor="city" className="label">
-          <Typography sx={{ display: 'inline' }}>Enter your city:</Typography>
+    <>
+      <form onSubmit={handleSubmit} className={styles.form}>
+        <label htmlFor='city' className='label'>
+          <Typography>Enter your city:</Typography>
         </label>
         <TextField
-          sx={{ mx: '1rem' }}
-          variant="standard"
-          list="places"
-          type="text"
-          id="city"
-          name="city"
+          variant='standard'
+          list='places'
+          type='text'
+          id='city'
+          name='city'
           onChange={handleCityChange}
           value={localCity}
           required
           pattern={autocompleteCities.join('|')}
-          autoComplete="off"
+          autoComplete='off'
+          data-testid='weather-form'
         />
-        {autocompleteErr && (
-          <span className="inputError">{autocompleteErr}</span>
-        )}
         {/* The datalist element gives the available options for the input. 
               The id="places" ties it to the element above with list="places" */}
-        <datalist id="places">
-          {autocompleteCities.map((city, i) => (
-            <option key={i}>{city}</option>
-          ))}
-        </datalist>
-        <Button type="submit" className="button" variant="outlined">
-          Submit
-        </Button>
+        {/* <datalist id='places'>
+        {autocompleteCities.map((city, i) => (
+          <option key={i}>{city}</option>
+        ))}
+      </datalist> */}
+        {/* <Button
+        type='submit'
+        className='button'
+        variant='outlined'
+        data-testid='weather-submit'
+      >
+        Submit
+      </Button> */}
       </form>
+      {autocompleteErr && <span className='inputError'>{autocompleteErr}</span>}
+      {}
+      <div>
+        <ul className={styles.list}>
+          {autocompleteCities.map((city, i) => (
+            <li key={i} onClick={handleSubmit} className={styles.option} data-testid={`cityPicker-${i}`}>
+              {city}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </>
   );
 };
 
 export default WeatherForm;
+
+function useDebounce(value, delay) {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}

--- a/src/components/WeatherForm/WeatherForm.jsx
+++ b/src/components/WeatherForm/WeatherForm.jsx
@@ -43,6 +43,7 @@ const WeatherForm = () => {
     };
 
     fetchCities();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [debouncedCity]);
 
   const handleSubmit = (e) => {

--- a/src/components/WeatherForm/WeatherForm.module.css
+++ b/src/components/WeatherForm/WeatherForm.module.css
@@ -1,0 +1,27 @@
+.form {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 1rem 0 0 0;
+  list-style-type: none;
+  padding: 0;
+  flex-basis: 100%;
+}
+
+.option {
+  background: #f6f7ff;
+  padding: 0.5rem;
+  border-radius: 5px;
+}
+
+.option:hover {
+  cursor: pointer;
+  background: #e2e4f3;
+}

--- a/src/features/weather/Weather.jsx
+++ b/src/features/weather/Weather.jsx
@@ -41,13 +41,13 @@ const Weather = () => {
         console.log(error);
       }
     };
-    fetchWeather();
+    city && fetchWeather();
   }, [city, dispatch]);
 
   const CurrentWeather = () => {
     return !loading ? (
       <Box
-        sx={{ display: "flex", flexDirection: "column", alignItems: "center" }}
+        sx={{ display: "flex", flexDirection: "column", alignItems: "center" }} data-testid="weather-info"
       >
         <img
           src={weatherIconSrc}

--- a/src/routes/Settings.jsx
+++ b/src/routes/Settings.jsx
@@ -28,7 +28,7 @@ export default function Settings() {
     return (
       <>
         <p>Current City: {city}</p>
-        <button onClick={setCity}>Change city</button>
+        <button onClick={setCity} data-testid="ChangeCity">Change city</button>
       </>
     );
   };


### PR DESCRIPTION
I created two "User journey" tests with Cypress. A user can enter a city, choose from a list of matching cities, and the weather will load for the selected city. Then, a user can change their city from the settings page.

I noticed that sometimes the call to `/api/weather` would timeout, so I wrote a `cy.intercept` as an alias and did `cy.wait(@getWeather)` to prevent same. This works locally, but not in CI.

I removed the intercept and wait, and it now works in CI. @mdwiltfong - could you look at cypress/e2e/weatherWidget.cy.js and let me know if I'm missing something about making the intercepts and waits work in CI?

Thanks!


---

Also of note, I improved the component overall - most notably I revived the city selector "drop-down" to choose a city.